### PR TITLE
The created_at timestamp was not being set on new sessions

### DIFF
--- a/lib/mysql2_session.rb
+++ b/lib/mysql2_session.rb
@@ -120,7 +120,7 @@ class Mysql2Session
     else
       # if @id is nil, we need to create a new session in the database
       # and set @id to the primary key of the inserted record
-      self.class.query("INSERT INTO sessions (`updated_at`, `session_id`, `data`) VALUES (NOW(), '#{@session_id}', #{self.class.quote(data)})")
+      self.class.query("INSERT INTO sessions (`created_at`, `updated_at`, `session_id`, `data`) VALUES (NOW(), NOW(), '#{@session_id}', #{self.class.quote(data)})")
       @id = connection.last_id
       @lock_version = 0
     end

--- a/lib/mysql_session.rb
+++ b/lib/mysql_session.rb
@@ -108,7 +108,7 @@ class MysqlSession
     else
       # if @id is nil, we need to create a new session in the database
       # and set @id to the primary key of the inserted record
-      self.class.query("INSERT INTO sessions (`updated_at`, `session_id`, `data`) VALUES (NOW(), '#{@session_id}', '#{Mysql::quote(data)}')")
+      self.class.query("INSERT INTO sessions (`created_at`, `updated_at`, `session_id`, `data`) VALUES (NOW(), NOW(), '#{@session_id}', '#{Mysql::quote(data)}')")
       @id = connection.insert_id
       @lock_version = 0
     end

--- a/lib/postgresql_session.rb
+++ b/lib/postgresql_session.rb
@@ -104,7 +104,7 @@ class PostgresqlSession
     else
       # if @id is nil, we need to create a new session in the database
       # and set @id to the primary key of the inserted record
-      connection.query("INSERT INTO sessions (\"updated_at\", \"session_id\", \"data\") VALUES (NOW(), #{@quoted_session_id}, #{quoted_data})")
+      connection.query("INSERT INTO sessions (\"created_at\", \"updated_at\", \"session_id\", \"data\") VALUES (NOW(), NOW(), #{@quoted_session_id}, #{quoted_data})")
       @id = connection.lastval rescue connection.query("select lastval()")[0][0].to_i
       @lock_version = 0
     end

--- a/lib/sqlite_session.rb
+++ b/lib/sqlite_session.rb
@@ -108,7 +108,7 @@ class SqliteSession
     else
       # if @id is nil, we need to create a new session in the database
       # and set @id to the primary key of the inserted record
-      self.class.query("INSERT INTO sessions ('id', `updated_at`, `session_id`, `data`) VALUES (NULL, datetime('now'), '#{@session_id}', '#{SQLite3::Database.quote(data)}')")
+      self.class.query("INSERT INTO sessions ('id', `created_at`, `updated_at`, `session_id`, `data`) VALUES (NULL, datetime('now'), datetime('now'), '#{@session_id}', '#{SQLite3::Database.quote(data)}')")
       @id = connection.last_insert_row_id()
       @lock_version = 0
       

--- a/test/unit/smart_session_test.rb
+++ b/test/unit/smart_session_test.rb
@@ -276,6 +276,16 @@ class SmartSessionTest < ActiveSupport::TestCase
     
   end
   
+  def test_created_at_is_set_on_creation
+    setup_base_session { |session| session[:foo] = "bar" }
+    assert_not_nil(ActiveRecord::Base.connection.select_value "SELECT created_at FROM sessions WHERE session_id = '123456'")
+  end
+  
+  def test_updated_at_is_set_on_creation
+    setup_base_session { |session| session[:foo] = "bar" }
+    assert_not_nil(ActiveRecord::Base.connection.select_value "SELECT updated_at FROM sessions WHERE session_id = '123456'")
+  end
+  
   private
   
   def assert_final_session expected
@@ -434,8 +444,6 @@ class FullStackTest < ActionController::IntegrationTest
       test_getting_session_id
     end
   end
-
-
 
   private
     def with_test_route_set


### PR DESCRIPTION
For restricting session longevity we needed this to be set correctly.

Best regards,
Krishna
